### PR TITLE
[IMP] payment_twikey: use the invoice's company where available

### DIFF
--- a/payment_twikey/__manifest__.py
+++ b/payment_twikey/__manifest__.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     "name": "Payment Provider: Twikey",
-    "version": "16.0-subver-dev",
+    "version": "16.0.1.0.0",
     "category": "Accounting/Payment Providers",
     "summary": "focus on recurring payments",
     'author': "Twikey N.V.",

--- a/payment_twikey/data/schedulers.xml
+++ b/payment_twikey/data/schedulers.xml
@@ -43,7 +43,7 @@
         <field name="name">Twikey: Invoice Sender</field>
         <field name="model_id" ref="model_account_move" />
         <field name="state">code</field>
-        <field name="code">model.send_invoices()</field>
+        <field name="code">model.send_invoices(cron=True)</field>
         <field name="interval_number">1</field>
         <field name="interval_type">hours</field>
         <field name="numbercall">-1</field>

--- a/payment_twikey/migrations/16.0.1.0.0/post-migration.py
+++ b/payment_twikey/migrations/16.0.1.0.0/post-migration.py
@@ -1,0 +1,9 @@
+from odoo import api, SUPERUSER_ID
+
+
+def migrate(cr, version):
+    """Update code of noupdate cron record."""
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    env.ref("payment_twikey.twikey_invoice_sender").write({
+        "code": "model.send_invoices(cron=True)",
+    })

--- a/payment_twikey/models/account_move.py
+++ b/payment_twikey/models/account_move.py
@@ -39,7 +39,7 @@ class AccountInvoice(models.Model):
 
     twikey_url = fields.Char(string="Twikey Invoice URL", help="URL of the Twikey Invoice",
                              store=True, compute="_compute_twikey_url",)
-    id_and_link_html = fields.Html(string="Twikey Invoice ID",compute='_compute_link_html')
+    id_and_link_html = fields.Html(string="Twikey Invoice URL (html)",compute='_compute_link_html')
 
     is_twikey_eligable = fields.Boolean(
         string="Invoice or Creditnote",
@@ -65,7 +65,7 @@ class AccountInvoice(models.Model):
         if twikey_client:
             # sometimes action_post gets called without an invoice record, in this case we don't try to
             # send anything to Twikey
-            to_be_send = self.search([('send_to_twikey', '=', True),('twikey_invoice_identifier','=',False),('state','=','posted')])
+            to_be_send = self.search([('company_id', '=', self.env.company.id), ('send_to_twikey', '=', True),('twikey_invoice_identifier','=',False),('state','=','posted')])
             if len(to_be_send) > 0:
                 # ensure logged in otherwise company of url might not be filled in
                 twikey_client.refreshTokenIfRequired()
@@ -214,12 +214,15 @@ class AccountInvoice(models.Model):
     def create(self, vals_list):
         """Set a default value for 'send_to_twikey' according to the standard rules."""
 
-        twikey_send_invoice = self.env.company.twikey_send_invoice
-        twikey_auto_collect = self.env.company.twikey_auto_collect
-        twikey_send_pdf = self.env.company.twikey_send_pdf
-        twikey_include_purchase = self.env.company.twikey_include_purchase
-
         for val in vals_list:
+            if val.get("company_id"):
+                company = self.env["res.company"].browse(val["company_id"])
+            else:
+                company = self.env.company
+            twikey_send_invoice = company.twikey_send_invoice
+            twikey_auto_collect = company.twikey_auto_collect
+            twikey_send_pdf = company.twikey_send_pdf
+            twikey_include_purchase = company.twikey_include_purchase
             if not val.get(F_SEND_TO_TWIKEY):
                 val[F_SEND_TO_TWIKEY] =  twikey_send_invoice
             if not val.get(F_AUTO_COLLECT_INVOICE):
@@ -262,7 +265,7 @@ class AccountInvoice(models.Model):
         Only certain types of account moves can be sent to Twikey.
         """
         for move in self:
-            if self.env.company.twikey_include_purchase:
+            if move.company_id.twikey_include_purchase:
                 move.is_twikey_eligable = move.move_type in ["in_invoice", "out_invoice", "out_refund"]
             else:
                 move.is_twikey_eligable = move.move_type in ["out_invoice", "out_refund"]
@@ -273,19 +276,20 @@ class AccountInvoice(models.Model):
         Calculate the url of the invoice in Twikey.
         """
         try:
-            twikey_client = (self.env["ir.config_parameter"].sudo().get_twikey_client(company=self.env.company))
-            for move in self:
-                if move.twikey_invoice_identifier:
-                    move.twikey_url = twikey_client.invoice.geturl(move.twikey_invoice_identifier)
+            for move in self.filtered("twikey_invoice_identifier"):
+                twikey_client = self.env["ir.config_parameter"].sudo().get_twikey_client(company=move.company_id)
+                move.twikey_url = twikey_client.invoice.geturl(move.twikey_invoice_identifier)
         except Exception as e:
             _logger.exception(e)
 
     @api.depends('twikey_invoice_identifier')
     def _compute_link_html(self):
-        twikey_client = (self.env["ir.config_parameter"].sudo().get_twikey_client(company=self.env.company))
         for record in self:
             # Generate the HTML link
-            record.id_and_link_html = f'<a href="{record.twikey_url}" target="twikey">{record.twikey_invoice_identifier}</a>'
+            record.id_and_link_html = (
+                f'<a href="{record.twikey_url}" target="twikey">{record.twikey_invoice_identifier}</a>'
+                if record.twikey_invoice_identifier else False
+            )
 
 class OdooInvoiceFeed(InvoiceFeed):
     def __init__(self, env, company):

--- a/payment_twikey/tests/__init__.py
+++ b/payment_twikey/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_model_account_move

--- a/payment_twikey/tests/common.py
+++ b/payment_twikey/tests/common.py
@@ -13,6 +13,12 @@ class TwikeyOdooCase(AccountTestInvoicingCommon):
         cls.company1.twikey_base_url = "https://example.com/api/v2"
         cls.company2.twikey_api_key = "key2"
         cls.company2.twikey_base_url = "https://example.com/api/v2"
+        cls.env = cls.env(
+            context=dict(
+                cls.env.context,
+                allowed_company_ids=[cls.company1.id, cls.company2.id]
+            )
+        )
         cls.invoice1 = cls.env["account.move"].create(
             {
                 "move_type": "out_invoice",

--- a/payment_twikey/tests/common.py
+++ b/payment_twikey/tests/common.py
@@ -1,0 +1,59 @@
+from odoo.fields import Command
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+class TwikeyOdooCase(AccountTestInvoicingCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company1 = cls.company_data["company"]
+        cls.company2 = cls.company_data_2["company"]
+        cls.company1.twikey_api_key = "key1"
+        cls.company1.twikey_base_url = "https://example.com/api/v2"
+        cls.company2.twikey_api_key = "key2"
+        cls.company2.twikey_base_url = "https://example.com/api/v2"
+        cls.invoice1 = cls.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "invoice_date": "2017-01-01",
+                "date": "2017-01-01",
+                "partner_id": cls.partner_a.id,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "name": "test line",
+                            "price_unit": 0.025,
+                            "quantity": 1,
+                            "account_id": cls.company_data[
+                                "default_account_revenue"
+                            ].id,
+                        }
+                    )
+                ],
+            }
+        )
+        cls.invoice2 = cls.env["account.move"].create(
+            {
+                "company_id": cls.company2.id,
+                "move_type": "out_invoice",
+                "invoice_date": "2017-01-01",
+                "date": "2017-01-01",
+                "partner_id": cls.partner_a.id,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "name": "test line",
+                            "price_unit": 0.025,
+                            "quantity": 1,
+                            "account_id": cls.company_data_2[
+                                "default_account_revenue"
+                            ].id,
+                        }
+                    )
+                ],
+            }
+        )
+
+        cls.invoice1.action_post()
+        cls.invoice2.action_post()

--- a/payment_twikey/tests/test_model_account_move.py
+++ b/payment_twikey/tests/test_model_account_move.py
@@ -1,0 +1,121 @@
+from unittest.mock import patch
+
+from odoo.fields import Command
+from odoo.tests import tagged
+
+from .common import TwikeyOdooCase
+
+
+@tagged("post_install", "-at_install")
+class TestModelAccountMove(TwikeyOdooCase):
+    def test_send_invoices(self):
+        """Only invoices are selected that match the company of the client."""
+        self.assertTrue(self.invoice1.is_twikey_eligable)
+        self.assertTrue(self.invoice2.is_twikey_eligable)
+        self.invoice1.btn_send_to_twikey()
+        self.invoice2.btn_send_to_twikey()
+        self.assertTrue(self.invoice1.send_to_twikey)
+        self.assertTrue(self.invoice2.send_to_twikey)
+
+        def transfer_to_twikey(invoices, client):
+            self.assertEqual(invoices, self.invoice1)
+            self.assertEqual(client.api_key, invoices.company_id.twikey_api_key)
+
+        with patch(
+            "odoo.addons.payment_twikey.models.account_move.AccountInvoice.transfer_to_twikey",
+            new=transfer_to_twikey,
+        ):
+            with patch(
+                "odoo.addons.payment_twikey.twikey.client.TwikeyClient.refreshTokenIfRequired"
+            ):
+                self.env["account.move"].with_company(self.company1).send_invoices()
+
+    def test_invoice_create(self):
+        """Invoices are assigned the parameters according to their company.
+
+        (and not the company of the environment).
+        """
+        self.company1.twikey_send_pdf = True
+        self.company2.twikey_send_pdf = False
+        invoice_company1 = (
+            self.env["account.move"]
+            .sudo()
+            .with_company(self.company2)
+            .create(
+                {
+                    "company_id": self.company1.id,
+                    "move_type": "out_invoice",
+                    "invoice_date": "2017-01-01",
+                    "date": "2017-01-01",
+                    "partner_id": self.partner_a.id,
+                    "invoice_line_ids": [
+                        Command.create(
+                            {
+                                "name": "test line",
+                                "price_unit": 0.025,
+                                "quantity": 1,
+                                "account_id": self.company_data[
+                                    "default_account_revenue"
+                                ].id,
+                            }
+                        )
+                    ],
+                }
+            )
+        )
+        invoice_company2 = (
+            self.env["account.move"]
+            .sudo()
+            .with_company(self.company1)
+            .create(
+                {
+                    "company_id": self.company2.id,
+                    "move_type": "out_invoice",
+                    "invoice_date": "2017-01-01",
+                    "date": "2017-01-01",
+                    "partner_id": self.partner_a.id,
+                    "invoice_line_ids": [
+                        Command.create(
+                            {
+                                "name": "test line",
+                                "price_unit": 0.025,
+                                "quantity": 1,
+                                "account_id": self.company_data_2[
+                                    "default_account_revenue"
+                                ].id,
+                            }
+                        )
+                    ],
+                }
+            )
+        )
+        self.assertTrue(invoice_company1.include_pdf_invoice)
+        self.assertFalse(invoice_company2.include_pdf_invoice)
+
+    def test_compute_twikey_url(self):
+        self.assertFalse(self.invoice1.id_and_link_html)
+        self.invoice1.twikey_invoice_identifier = "123"
+        self.assertIn("https://app.twikey.com/0/123", self.invoice1.id_and_link_html)
+
+    def test_compute_twikey_url_company(self):
+        """Client is fetched with the company of the invoice."""
+
+        def geturl(klass, invoice_identifier):
+            """The invoice_identifier is set to the api_key of the invoice's company.
+
+            Check that the client matches the company by comparing the api key.
+            """
+            self.assertEqual(invoice_identifier, klass.client.api_key)
+            return invoice_identifier
+
+        with patch(
+            "odoo.addons.payment_twikey.twikey.invoice.Invoice.geturl",
+            new=geturl,
+        ):
+            self.invoice1.twikey_invoice_identifier = (
+                self.invoice1.company_id.twikey_api_key
+            )
+            self.invoice2.twikey_invoice_identifier = (
+                self.invoice2.company_id.twikey_api_key
+            )
+            self.env["account.move"].flush_model()

--- a/payment_twikey/views/account_move.xml
+++ b/payment_twikey/views/account_move.xml
@@ -40,9 +40,16 @@
         <field name="code">records.btn_send_to_twikey()</field>
     </record>
 
+    <record id="action_send_invoices_to_twikey" model="ir.actions.server">
+        <field name="name">Send Invoices to Twikey</field>
+        <field name="model_id" ref="account.model_account_move"/>
+        <field name="state">code</field>
+        <field name="code">model.send_invoices()</field>
+    </record>
+
     <menuitem
             id="menu_action_twikey"
-            action="model_account_move_send_to_twikey"
+            action="action_send_invoices_to_twikey"
             parent="contacts.res_partner_menu_config"
             sequence="1"
     />


### PR DESCRIPTION
Also fix warning

```
odoo.addons.base.models.ir_model: Two fields (id_and_link_html, twikey_invoice_identifier) of account.move() have the same label: Twikey Invoice ID. [Modules: payment_twikey and payment_twikey]
```

and fix traceback
```
ValueError: <class 'AttributeError'>: "'NoneType' object has no attribute 'btn_send_to_twikey'" while evaluating
'records.btn_send_to_twikey
```
when clicking the Send to Twikey menuitem.