### PR TITLE
Treat any customer with a VAT number as a company

### DIFF
--- a/payment_twikey/utils.py
+++ b/payment_twikey/utils.py
@@ -22,7 +22,9 @@ def get_twikey_customer(partner):
         "country": partner.country_id.code if partner.country_id else "",
     }
     # if owner is company treat is as such
-    if owner.company_type == "company" and owner.name:
+    # in Twikey any entity with a VAT & company name
+    # is considered a company
+    if owner.vat and owner.name:
         customer["companyName"] = owner.name
         if owner.vat:
             customer["coc"] = owner.vat

--- a/payment_twikey/utils.py
+++ b/payment_twikey/utils.py
@@ -21,13 +21,11 @@ def get_twikey_customer(partner):
         "zip": partner.zip if partner.zip else "",
         "country": partner.country_id.code if partner.country_id else "",
     }
+
     # if owner is company treat is as such
-    # in Twikey any entity with a VAT & company name
-    # is considered a company
-    if owner.vat and owner.name:
-        customer["companyName"] = owner.name
-        if owner.vat:
-            customer["coc"] = owner.vat
+    if owner.vat:
+        customer["companyName"] = owner.company_name if owner.company_name else owner.name
+        customer["coc"] = owner.vat
 
     if partner.mobile:
         customer["mobile"] = partner.mobile


### PR DESCRIPTION
In Twikey a customer is considered a company the moment they have a VAT number and company name. This PR translates that logic in the Odoo plugin. Instead of checking the company_type from odoo we simply check wether a VAT number is set. If so we check if a company name was provided otherwise we fallback to simply using the full name of the customer in question as a company name.